### PR TITLE
use first-class polymorphism for request handlers

### DIFF
--- a/src/types.ml
+++ b/src/types.ml
@@ -100,3 +100,6 @@ type _ ssh_agent_response =
 
 type any_ssh_agent_response =
   Any_response : 'a ssh_agent_response -> any_ssh_agent_response
+
+type request_handler =
+  { handle : 'a . 'a ssh_agent_request -> 'a ssh_agent_response; }

--- a/unix/ssh_agent_unix.ml
+++ b/unix/ssh_agent_unix.ml
@@ -18,10 +18,10 @@ let request ((ic, oc) : in_channel * out_channel)
     Error ("Parse error: " ^ e)
 
 let listen ((ic, oc) : in_channel * out_channel)
-    (handler : 'a Ssh_agent.ssh_agent_request -> 'a Ssh_agent.ssh_agent_response) =
+      (handler : Ssh_agent.request_handler) =
   match Angstrom_unix.parse Ssh_agent.Parse.ssh_agentc_message ic with
   | { len = 0; _ }, Ok (Ssh_agent.Any_request request) ->
-    Ok (Ssh_agent.Any_response (handler request))
+    Ok (Ssh_agent.Any_response (handler.handle request))
   | { len; _ }, Ok _ ->
     Error "Additional data in request"
   | _, Error e ->


### PR DESCRIPTION
Record fields and object methods can have a polymorphic type of the form

    'a . 'a request -> 'a response

which is precisely required to correctly type-check the parameter of
the 'listen' function. This is a polymorphic type (it means: "forall
'a, ..."), so the instantiation of the parameter ('a) is local to the
callsite, and thus it does not let the existential parameter of the
request type escape.

cc @infinity0